### PR TITLE
Fix duplicate enum types error

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 History
 =======
 
+
+0.1.1 (2020-08-31)
+------------------
+
+* Fix duplicate enum types error when multiple columns reuse one SQLAlchemy enum or when enum types are used as field arguments
+
+
 0.1.0 (2020-08-17)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ graphene-objecttype-from-sqlalchemy-table
         :target: https://pypi.python.org/pypi/graphene_objecttype_from_sqlalchemy_table
 
 .. image:: https://travis-ci.com/Joko013/graphene-objecttype-from-sqlalchemy-table.svg?token=FHRZRddxayyoV31ugrQS&branch=master
-    :target: https://travis-ci.com/Joko013/graphene-objecttype-from-sqlalchemy-table
+    :target: https://travis-ci.org/Joko013/graphene-objecttype-from-sqlalchemy-table
 
 
 

--- a/graphene_objecttype_from_sqlalchemy_table/__init__.py
+++ b/graphene_objecttype_from_sqlalchemy_table/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Jan Klima"""
 __email__ = 'klima013@gmail.com'
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 
 from .type import ObjectTypeFromTable

--- a/graphene_objecttype_from_sqlalchemy_table/convert.py
+++ b/graphene_objecttype_from_sqlalchemy_table/convert.py
@@ -7,7 +7,7 @@ from graphene.types import Boolean, Date, DateTime, Float, ID, Int, JSONString, 
 from graphene.types.enum import EnumMeta
 from sqlalchemy import types, Column
 
-from .enum import get_enum_from_column, is_enum, get_enum_resolver
+from .enum import get_enum_from_sa_enum, get_enum_resolver
 
 
 @singledispatch
@@ -29,11 +29,12 @@ def convert_column_type(type_, column: Column):
 
 @convert_column_type.register(types.String)
 def _to_string_or_enum(type_, column):
-    if is_enum(column):
-        # enums are interpreted as varchar
-        return get_enum_from_column(column=column)
-    else:
-        return String
+    return String
+
+
+@convert_column_type.register(types.Enum)
+def _to_enum(type_, column):
+    return get_enum_from_sa_enum(sa_enum=column.type)
 
 
 @convert_column_type.register(types.DateTime)

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/Joko013/graphene-objecttype-from-sqlalchemy-table',
-    version='0.1.0',
+    version='0.1.1',
     zip_safe=False,
 )

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -34,7 +34,7 @@ def test_convert_type_primary_key():
 
 def test_convert_type_enum(mocker):
     graphene_enum = Enum("test", [("one", 1), ("two", 2)])
-    mocker.patch("graphene_objecttype_from_sqlalchemy_table.convert.get_enum_from_column", return_value=graphene_enum)
+    mocker.patch("graphene_objecttype_from_sqlalchemy_table.convert.get_enum_from_sa_enum", return_value=graphene_enum)
 
     enum = types.Enum("one", "two", name="test_enum")
     column = Column('test', enum)

--- a/tests/unit/test_enum.py
+++ b/tests/unit/test_enum.py
@@ -1,30 +1,19 @@
 
 import pytest
 from graphene.types.enum import Enum, EnumMeta
-from sqlalchemy import types, Column
+from sqlalchemy import types
 
-from graphene_objecttype_from_sqlalchemy_table.enum import is_enum, get_enum_from_column, get_enum_resolver
-
-
-@pytest.mark.parametrize(
-    'col_type, result',
-    [
-        (types.Enum('foo', 'bar', name='test_enum'), True),
-        (types.String, False),
-    ]
-)
-def test_is_enum(col_type, result):
-    column = Column(name='test', type_=col_type)
-    assert is_enum(column) == result
+from graphene_objecttype_from_sqlalchemy_table.enum import get_enum_from_sa_enum, get_enum_resolver, enum_registry
 
 
-def test_get_enum_from_column():
+def test_get_enum_from_sa_enum():
     enum = types.Enum('foo', 'bar', name='test_enum')
-    column = Column('test', enum)
-    result = get_enum_from_column(column)
+    result = get_enum_from_sa_enum(sa_enum=enum)
+    result_ = get_enum_from_sa_enum(sa_enum=enum)
     assert (
         isinstance(result, EnumMeta) and
-        all(getattr(result, e, None) is not None for e in enum.enums)
+        all(getattr(result, e, None) is not None for e in enum.enums) and
+        result is result_ is enum_registry[enum.name]  # test that duplicate types are not being created
     )
 
 


### PR DESCRIPTION
When a table contains one enum used for multiple columns, an assertion error is raised during schema creation.
`AssertionError: Found different types with the same name in the schema: enum_type, enum_type.`

It can be fixed by creating an enum registry where the created types are stored. If another column referencing the same enum name is being converted, it will use the type from registry instead of creating a new one.