### PR TITLE
new pypi release

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,10 +3,16 @@ History
 =======
 
 
+0.1.2 (2020-09-02)
+------------------
+
+* No changes, Travis CI encryption issues caused incorrect pypi release, pypi doesn't allow deleting and re-releasing the same version hence a new version is needed to fix this.
+
+
 0.1.1 (2020-08-31)
 ------------------
 
-* Fix duplicate enum types error when multiple columns reuse one SQLAlchemy enum or when enum types are used as field arguments
+* Fix duplicate enum types error when multiple columns reuse one SQLAlchemy enum or when enum types are used as field arguments.
 
 
 0.1.0 (2020-08-17)

--- a/graphene_objecttype_from_sqlalchemy_table/__init__.py
+++ b/graphene_objecttype_from_sqlalchemy_table/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Jan Klima"""
 __email__ = 'klima013@gmail.com'
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 
 
 from .type import ObjectTypeFromTable

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/Joko013/graphene-objecttype-from-sqlalchemy-table',
-    version='0.1.1',
+    version='0.1.2',
     zip_safe=False,
 )


### PR DESCRIPTION
travis ci encryption issues caused an unwanted pypi release, so the master couldn't be released since pypi doesn't allow deleting and re-releasing versions -> a new version is required